### PR TITLE
fix: add proper users in node18

### DIFF
--- a/node18/Dockerfile.23.04
+++ b/node18/Dockerfile.23.04
@@ -1,18 +1,20 @@
 ARG UBUNTU_RELEASE=23.04
-ARG USER=ubuntu UID=101 GROUP=ubuntu GID=101
+ARG USER=app UID=101 GROUP=app GID=101
 
 FROM ubuntu:$UBUNTU_RELEASE AS builder
 ARG USER UID GROUP GID TARGETARCH
 SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
+
 ADD https://github.com/canonical/chisel/releases/download/v0.8.0/chisel_v0.8.0_linux_${TARGETARCH}.tar.gz chisel.tar.gz
 RUN tar -xvf chisel.tar.gz -C /usr/bin/
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-RUN mkdir -p /rootfs/etc \
-    && echo "$GROUP:x:$GID:" >/rootfs/etc/group \
-    && echo "$USER:x:$UID:$GID::/nohome:/noshell" >/rootfs/etc/passwd
+RUN install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+    && mkdir -p /rootfs/etc \
+    && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
 RUN chisel cut --root /rootfs \
     base-files_base \
     base-files_release-info \
@@ -25,8 +27,11 @@ RUN chisel cut --root /rootfs \
     nodejs_bins
 
 FROM scratch
-ARG UID GID
+ARG USER UID GROUP GID
 USER $UID:$GID
+
 COPY --from=builder /rootfs /
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=builder --chown=$UID:$GID /rootfs/home/$USER /home/$USER
 
 ENTRYPOINT [ "node" ]


### PR DESCRIPTION
This PR changes the username and group from ``ubuntu`` to ``app`` to align with the rest of the chiselled images. It also creates a home directory for the ``app`` user.