### PR TITLE
feat: add 24.04 image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   node18-image: ubuntu/chiselled-node:18-test
-  ubuntu-release: 23.04
+  ubuntu-release: 24.04
 
 jobs:
   test:

--- a/node18/Dockerfile.24.04
+++ b/node18/Dockerfile.24.04
@@ -1,0 +1,37 @@
+ARG UBUNTU_RELEASE=24.04
+ARG USER=app UID=101 GROUP=app GID=101
+
+FROM ubuntu:$UBUNTU_RELEASE AS builder
+ARG USER UID GROUP GID TARGETARCH
+SHELL ["/bin/bash", "-oeux", "pipefail", "-c"]
+
+ADD https://github.com/canonical/chisel/releases/download/v0.9.0/chisel_v0.9.0_linux_${TARGETARCH}.tar.gz chisel.tar.gz
+RUN tar -xvf chisel.tar.gz -C /usr/bin/
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+RUN install -d -m 0755 -o $UID -g $GID /rootfs/home/$USER \
+    && mkdir -p /rootfs/etc \
+    && echo -e "root:x:0:\n$GROUP:x:$GID:" >/rootfs/etc/group \
+    && echo -e "root:x:0:0:root:/root:/noshell\n$USER:x:$UID:$GID::/home/$USER:/noshell" >/rootfs/etc/passwd
+RUN chisel cut --root /rootfs \
+    base-files_base \
+    base-files_release-info \
+    tzdata_zoneinfo \
+    ca-certificates_data \
+    openssl_config \
+    openssl_data \
+    libgcc-s1_libs \
+    libc6_libs \
+    nodejs_bins
+
+FROM scratch
+ARG USER UID GROUP GID
+USER $UID:$GID
+
+COPY --from=builder /rootfs /
+# Workaround for https://github.com/moby/moby/issues/38710
+COPY --from=builder --chown=$UID:$GID /rootfs/home/$USER /home/$USER
+
+ENTRYPOINT [ "node" ]

--- a/node18/README.md
+++ b/node18/README.md
@@ -3,7 +3,7 @@
 This directory contains the image recipes of Chiselled Node.js 18 LTS. These images are smaller in size,
 hence less prone to vulnerabilities. Know more about chisel [here](https://github.com/canonical/chisel).
 
-We currently have Chiselled Node.js only on lunar. See [Dockerfile.23.04](./Dockerfile.23.04).
+We currently have Chiselled Node.js only on noble. See [Dockerfile.24.04](./Dockerfile.24.04).
 
 ### Building the image(s)
 
@@ -11,7 +11,7 @@ Build the Dockerfile(s) in the usual way:
 
 ```sh
 # NOTE: export DOCKER_BUILDKIT=1 if you're running on an older Docker version
-$ docker build -t ubuntu/chiselled-node:18 --load -f node18/Dockerfile.23.04 node18
+$ docker build -t ubuntu/chiselled-node:18 --load -f node18/Dockerfile.24.04 node18
 ```
 
 ### Run the image(s)


### PR DESCRIPTION
Goes well with #6.

Note that the builds will fail because of the changed paths in libc6:  https://github.com/canonical/chisel-releases/pull/148.