### PR TITLE
feat: add Node.js 20 rock for Noble

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 env:
   node18-image: ubuntu/chiselled-node:18-test
+  node20-image: ubuntu/nodejs:20-test
   ubuntu-release: 24.04
 
 jobs:
@@ -35,6 +36,13 @@ jobs:
             --output type=oci,dest="chiselled-node.${{ matrix.arch }}.tar" \
             node18
 
+      - name: Build the ${{ env.node20-image }} image on ${{ matrix.arch }}
+        id: build
+        uses: canonical/craft-actions/rockcraft-pack@main
+        with:
+          path: node20/
+          verbosity: debug
+
       - name: Run tests
         if: ${{ matrix.arch == 'amd64' }}
         run: |
@@ -42,7 +50,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y skopeo
           skopeo copy oci-archive:"chiselled-node.${{ matrix.arch }}.tar" docker-daemon:${{ env.node18-image }}
+          skopeo copy oci-archive:node20/nodejs_20_amd64.rock docker-daemon:${{ env.node20-image }}
           ./tests/run-all-tests ${{ env.node18-image }}
+          ./tests/run-all-tests ${{ env.node20-image }}
 
       - uses: actions/upload-artifact@v3
         with:

--- a/node20/README.md
+++ b/node20/README.md
@@ -1,0 +1,171 @@
+# Node.js 20 Rock
+
+This directory contains the image recipes of Node.js 20 rock. These images are smaller in size,
+hence less prone to vulnerabilities.
+
+We currently have Node.js 20 only on noble.
+
+### Building the image(s)
+
+Pack the rockcraft.yaml in the usual way:
+
+```sh
+$ rockcraft pack
+```
+
+Convert the rock to a Docker image using the `skopeo` tool:
+
+```sh
+$ skopeo --insecure-policy copy \
+      oci-archive:nodejs_20_amd64.rock \
+      docker-daemon:ubuntu/nodejs:20
+```
+
+### Run the image(s)
+
+The image has the "node" binary as the entrypoint.
+
+```sh
+$ docker run -it ubuntu/nodejs:20
+Welcome to Node.js v20.12.0.
+Type ".help" for more information.
+...
+```
+
+### Building and running an application on Node.js rock
+
+#### Simple One-File Application
+
+Let's assume, you have the following `app.js` you want to run as an application.
+
+```js
+console.log("Hello World");
+```
+
+You may create the following Dockerfile for your application image:
+
+```Dockerfile
+FROM ubuntu/nodejs:20
+
+ADD app.js /
+
+ENTRYPOINT ["node", "app.js"]
+```
+
+Build the image:
+
+```sh
+$ docker build -t myapp -f Dockerfile.app .
+```
+
+Run your application container:
+
+```sh
+$ docker run myapp
+Hello World
+```
+
+#### Multi-File Application
+
+If you have a JavaScript/TypeScript application managed using `npm`, `yarn`, `pnpm` or some other package manager,
+you might want to bundle your application using a bundler that bundles your `node_modules` and your
+application into one single file.
+
+There are a lot of different bundlers that may be suitable for your application, like [`esbuild`](https://esbuild.github.io/), [`rspack`](https://www.rspack.dev/),
+[`vite`](https://vitejs.dev/), [`rollup`](https://rollupjs.org/), [`farm`](https://farm-fe.github.io/), [`webpack`](https://webpack.js.org/), [`parcel`](https://parceljs.org/) and so forth.
+You might want to pick one that suit your project best and use that to bundle your application.
+
+Do note that bundlers may break your application in unexpected ways
+(due to tree-shaking and identifier minification), so please do test the bundled application thoroughly.
+
+For the purposes of this tutorial, we will use `esbuild` with a simple TypeScript project.
+
+Let's assume you have a project with the entry point like this:
+
+```ts
+import dayjs from "dayjs";
+
+async function test_temporal() {
+  return dayjs().format("YYYY-MM-DD");
+}
+
+console.log(await test_temporal());
+```
+
+And your `package.json` might look like this:
+
+```json
+{
+    "name": "test-app",
+    "version": "1.0.0",
+    "main": "index.js",
+    "license": "MIT",
+    "scripts": {
+        "build": "esbuild --target=node20 --bundle --minify --platform=node main.ts --outfile=dist/index.js",
+        "check": "tsc -p tsconfig.json --noEmit"
+    },
+    "dependencies": {
+        "dayjs": "^1",
+    },
+    "devDependencies": {
+        "@tsconfig/node20": "^20",
+        "esbuild": "^0.19",
+        "typescript": "^5"
+    }
+}
+```
+
+Note that we added two scripts for convenience.
+
+Now we can create a multi-stage Dockerfile that builds the application in a full-featured container
+and then deploy the built application into the chiselled container.
+
+```dockerfile
+FROM ubuntu/nodejs:20
+
+RUN mkdir /src
+WORKDIR /src
+COPY . .
+RUN npm ci && npm run check && npm run build
+RUN cp dist/index.js /index.js
+RUN rm -rf /src
+
+ENTRYPOINT ["node", "/index.js"]
+```
+
+Build the image:
+
+```sh
+$ docker build -t myapp -f Dockerfile.app .
+```
+
+Run your application container:
+
+```sh
+$ docker run myapp
+2024-03-28
+```
+
+If your application contains Node.js native extensions, you should copy those extensions to the chiselled container as well.
+If you are unsure if your application has those extensions, run the following command after populating `node_modules`:
+
+```sh
+find node_modules -name '*.node' -type f -print
+```
+
+If nothing got printed out, then it means your application does not have any native extensions.
+If you got any output, then you need to copy those files to the container with the same path as well,
+for instance:
+
+If you got `node_modules/@serialport/bindings-cpp/prebuilds/linux-x64/node.napi.glibc.node` in the output,
+and copied your JavaScript file to `/app/index.js`, you need to copy the native extension file to
+`/app/node_modules/@serialport/bindings-cpp/prebuilds/linux-x64/node.napi.glibc.node`.
+
+If your application contains WebAssembly bits, you should also copy those to the chiselled container.
+Use the following command to find them:
+
+```sh
+find node_modules -name '*.wasm' -type f -print
+```
+
+You can take a look at [tests/app_simple-wasm](../tests/app_simple-wasm/) for inspirations.

--- a/node20/rockcraft.yaml
+++ b/node20/rockcraft.yaml
@@ -1,0 +1,40 @@
+name: nodejs
+base: bare
+build-base: devel
+version: '20'
+summary: Node.js 20 rock
+description: |
+    Node.js is a free, open-source, cross-platform JavaScript runtime
+    environment that lets developers create servers, web apps, command line
+    tools and scripts.
+    This image is a chiselled Node.js rock that contains Node.js runtime in
+    addition to some Node.js tools such as npx, npm and yarn.
+license: MIT
+platforms:
+    amd64:
+
+run-user: _daemon_
+
+parts:
+    nodejs:
+        plugin: nil
+        stage-packages:
+          - bash_bins
+          - base-files_lib
+          - coreutils_bins
+          - libbrotli1_libs
+          - libc-ares2_libs
+          - libicu74_libs
+          - libnghttp2-14_libs
+          - libssl3_libs
+          - libstdc++6_libs
+          - libuv1_libs
+          - sed_bins
+          - zlib1g_libs
+        stage-snaps:
+          - node/20
+        override-prime: |
+          craftctl default
+          ln -s ${CRAFT_PRIME}/usr/bin/bash ${CRAFT_PRIME}/bin/sh
+          ln -s ${CRAFT_PRIME}/bin/node ${CRAFT_PRIME}/bin/nodejs
+          ln -s ${CRAFT_PRIME}/bin/node ${CRAFT_PRIME}/bin/js

--- a/node20/rockcraft.yaml
+++ b/node20/rockcraft.yaml
@@ -19,9 +19,7 @@ parts:
     nodejs:
         plugin: nil
         stage-packages:
-          - bash_bins
           - base-files_lib
-          - coreutils_bins
           - libbrotli1_libs
           - libc-ares2_libs
           - libicu74_libs
@@ -29,12 +27,13 @@ parts:
           - libssl3_libs
           - libstdc++6_libs
           - libuv1_libs
-          - sed_bins
           - zlib1g_libs
         stage-snaps:
           - node/20
         override-prime: |
           craftctl default
-          ln -s ${CRAFT_PRIME}/usr/bin/bash ${CRAFT_PRIME}/bin/sh
+          rm -rf ${CRAFT_PRIME}/lib/node_modules/
+          rm ${CRAFT_PRIME}/bin/npm ${CRAFT_PRIME}/bin/npx
+          rm ${CRAFT_PRIME}/bin/corepack ${CRAFT_PRIME}/bin/yarn*
           ln -s ${CRAFT_PRIME}/bin/node ${CRAFT_PRIME}/bin/nodejs
           ln -s ${CRAFT_PRIME}/bin/node ${CRAFT_PRIME}/bin/js

--- a/node20/rockcraft.yaml
+++ b/node20/rockcraft.yaml
@@ -7,8 +7,8 @@ description: |
     Node.js is a free, open-source, cross-platform JavaScript runtime
     environment that lets developers create servers, web apps, command line
     tools and scripts.
-    This image is a chiselled Node.js rock that contains Node.js runtime in
-    addition to some Node.js tools such as npx, npm and yarn.
+    This image is a chiselled Node.js rock that only contains the Node.js
+    runtime.
 license: MIT
 platforms:
     amd64:
@@ -27,6 +27,9 @@ parts:
           - libssl3_libs
           - libstdc++6_libs
           - libuv1_libs
+          - openssl_config
+          - openssl_data
+          - tzdata_zoneinfo
           - zlib1g_libs
         stage-snaps:
           - node/20

--- a/tests/app_hello-world/runtest
+++ b/tests/app_hello-world/runtest
@@ -4,7 +4,11 @@ set -ex
 echo "Running test for Hello World app..."
 
 test() {
-	docker run --rm -v "$PWD/src":/src:ro "$1" /src/main.js
+	if [ "$1" == "$NODE18" ]; then
+		docker run --rm -v "$PWD/src":/src:ro "$1" /src/main.js
+	else
+		docker run --rm -v "$PWD/src":/src:ro "$1" exec node /src/main.js
+	fi
 }
 
-test "$NODE18"
+test "$NODE_X"

--- a/tests/app_http-server/runtest
+++ b/tests/app_http-server/runtest
@@ -5,7 +5,11 @@ echo "Running test for HTTP Server app..."
 
 test() {
 	port=1234
-	container="$(docker run -d --rm -v "$PWD/src":/src:ro -p $port:8080 "$1" /src/main.js)"
+	if [ "$1" == "$NODE18" ]; then
+		container="$(docker run -d --rm -v "$PWD/src":/src:ro -p $port:8080 "$1" /src/main.js)"
+	else
+		container="$(docker run -d --rm -v "$PWD/src":/src:ro -p $port:8080 "$1" exec node /src/main.js)"
+	fi
 	sleep 1
 	output="$(curl http://localhost:$port/)"
 	[ "$output" == "Hello world!" ] || exit 1
@@ -16,4 +20,4 @@ cleanup() {
 }
 trap cleanup EXIT
 
-test "$NODE18"
+test "$NODE_X"

--- a/tests/app_simple-modules/runtest
+++ b/tests/app_simple-modules/runtest
@@ -9,8 +9,12 @@ build() {
 }
 
 test() {
-	docker run --rm -v "$PWD/dist":/src:ro "$1" /src/index.js
+    if [ "$1" == "$NODE18" ]; then
+        docker run --rm -v "$PWD/dist":/src:ro "$1" /src/index.js
+    else
+        docker run --rm -v "$PWD/dist":/src:ro "$1" exec node /src/index.js
+    fi
 }
 
 build
-test "$NODE18"
+test "$NODE_X"

--- a/tests/app_simple-typescript/runtest
+++ b/tests/app_simple-typescript/runtest
@@ -11,7 +11,11 @@ build() {
 
 test() {
 	port=1234
-	container="$(docker run -d --rm -v "$PWD/dist":/src:ro -p $port:3000 "$1" /src/index.js)"
+	if [ "$1" == "$NODE18" ]; then
+		container="$(docker run -d --rm -v "$PWD/dist":/src:ro -p $port:3000 "$1" /src/index.js)"
+	else
+		container="$(docker run -d --rm -v "$PWD/dist":/src:ro -p $port:3000 "$1" exec node /src/index.js)"
+	fi
 	sleep 1
 	local output expected
 	output="$(curl http://localhost:$port/)"
@@ -27,4 +31,4 @@ cleanup() {
 trap cleanup EXIT
 
 build
-test "$NODE18"
+test "$NODE_X"

--- a/tests/app_simple-wasm/runtest
+++ b/tests/app_simple-wasm/runtest
@@ -11,8 +11,12 @@ build() {
 }
 
 test() {
-	docker run --rm -v "$PWD/dist":/src:ro "$1" /src/index.mjs
+    if [ "$1" == "$NODE18" ]; then
+        docker run --rm -v "$PWD/dist":/src:ro "$1" /src/index.mjs
+    else
+        docker run --rm -v "$PWD/dist":/src:ro "$1" exec node /src/index.mjs
+    fi
 }
 
 build
-test "$NODE18"
+test "$NODE_X"

--- a/tests/run-all-tests
+++ b/tests/run-all-tests
@@ -3,7 +3,9 @@ set -ex
 
 echo "Running tests..."
 
-export NODE18=${1:-"ubuntu/chiselled-node:18-test"}
+export NODE_X=${1:-"ubuntu/chiselled-node:18-test"}
+export NODE18="ubuntu/chiselled-node:18-test"
+export NODE20="ubuntu/nodejs:20-test"
 
 CURRENT_DIR="$(dirname "$(readlink -f "$0")")"
 


### PR DESCRIPTION
This add the rockcraft.yaml for Node.js built on 24.04.

Since there is no apt package for Node.js 20 on 24.04 yet (currently there is only Node.js 18 there), I opted to install Nodejs binaries using snap instead.

Note that the Nodejs snap include the package managers npm and yarn. yarn in particular needs bash, coreutils and sed to work because it is basically a shell script.

This is waiting on https://github.com/canonical/chisel-releases/pull/182 to be merged.