### PR TITLE
build(node18): add part for security manifest

### DIFF
--- a/node18/rockcraft.yaml
+++ b/node18/rockcraft.yaml
@@ -29,3 +29,47 @@ parts:
           - libgcc-s1_libs
           - libc6_libs
           - nodejs_bins
+    manifest:
+        plugin: nil
+        after: [node]
+        build-packages:
+            - zstd
+            - jq
+        override-build: |
+            mkdir -p $CRAFT_PART_INSTALL/usr/share/rocks
+            FIELDS=(
+                '${db:Status-Abbrev}'
+                '${binary:Package}'
+                '${Version}'
+                '${source:Package}'
+                '${Source:Version}\n'
+            )
+            zstd -d -f -q $CRAFT_STAGE/var/lib/chisel/manifest.wall \
+                -o $CRAFT_PART_BUILD/manifest
+
+            # Awk fortmat
+            awk_script='
+            {
+                binary=$1
+                version=$2
+                cmd = "dpkg-query -W -f='\''${source:Package}\n'\'' " binary " | head -n 1"
+                if ((cmd | getline source) > 0) {
+                    print "ii ," binary ":" arch "," version "," source "," version
+                }
+                close(cmd)
+            }'
+
+            # Create security manifest file
+            (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query") \
+            > $CRAFT_PART_INSTALL/usr/share/rocks/dpkg.query
+
+            # Add packages
+            (
+                awk -v arch=${CRAFT_ARCH_BUILD_FOR} -F' ' "$awk_script" <<< \
+                $(
+                    jq -r 'select(.kind == "package") | "\(.name) \(.version)"' \
+                    $CRAFT_PART_BUILD/manifest
+                )
+            ) >> $CRAFT_PART_INSTALL/usr/share/rocks/dpkg.query
+
+            craftctl default


### PR DESCRIPTION
Added a new part to include the security manifest for security monitoring.

Once packed and `skopeo-copy`ed the image you can run this to check the content of the manifest:
```
docker run -it node:18 exec node -e "require('fs').readFileSync('/usr/share/rocks/dpkg.query', 'utf8').split('\n').forEach(line => console.log(line));"
```

NOTE: This part can be removed once the fetch service becomes available in OCI Factory and a script to generate the manifest is added to the pipeline. See https://github.com/canonical/rocks-toolbox/pull/28